### PR TITLE
Nitpick: Remove unnecessary `application` plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java'
 apply plugin: 'idea'
-apply plugin: 'application'
 apply plugin: 'gauge'
 
 group = "gauge-example-java"


### PR DESCRIPTION
Gradle isn't configured correctly for this; you need to specify a `mainClassName` which isn't really relevant for this example project.

Resolves #14 